### PR TITLE
Skip executing doPostSetUserClaimValuesWithID in IDV listener in tenant creation flow

### DIFF
--- a/components/org.wso2.carbon.extension.identity.verification.mgt/pom.xml
+++ b/components/org.wso2.carbon.extension.identity.verification.mgt/pom.xml
@@ -97,6 +97,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.multitenancy</groupId>
+            <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
+        </dependency>
 
         <!--Test dependencies-->
         <dependency>
@@ -162,6 +166,7 @@
                             org.apache.http.impl.client; version="${httpcomponents-httpclient.imp.pkg.version.range}",
                             org.apache.http.impl.conn; version="${httpcomponents-httpclient.imp.pkg.version.range}",
                             org.wso2.carbon.extension.identity.verification.provider.model,
+                            org.wso2.carbon.tenant.mgt.util.*;version="${carbon.multitenancy.imp.pkg.version}",
                             org.wso2.carbon.identity.core.cache; version="${carbon.identity.package.import.version.range}"
                         </Import-Package>
                         <Export-Package>

--- a/components/org.wso2.carbon.extension.identity.verification.mgt/src/main/java/org/wso2/carbon/extension/identity/verification/mgt/listeners/IdVUserOperationEventListener.java
+++ b/components/org.wso2.carbon.extension.identity.verification.mgt/src/main/java/org/wso2/carbon/extension/identity/verification/mgt/listeners/IdVUserOperationEventListener.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.extension.identity.verification.mgt.exception.IdentityVer
 import org.wso2.carbon.extension.identity.verification.mgt.model.IdVClaim;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.tenant.mgt.util.TenantMgtUtil;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
@@ -126,6 +127,11 @@ public class IdVUserOperationEventListener extends AbstractIdentityUserOperation
                                                   UserStoreManager userStoreManager) throws UserStoreException {
 
         if (!isEnable() || userStoreManager == null) {
+            return true;
+        }
+
+        boolean isTenantCreationOperation = TenantMgtUtil.isTenantCreation();
+        if (isTenantCreationOperation) {
             return true;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,11 @@
                 <version>${carbon.identity.framework.version}</version>
                 <scope>provided</scope>
             </dependency>
-
+            <dependency>
+                <groupId>org.wso2.carbon.multitenancy</groupId>
+                <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
+                <version>${carbon.multitenancy.version}</version>
+            </dependency>
 
             <!--Test dependencies-->
             <dependency>
@@ -437,6 +441,10 @@
         <encoder-jsp.version>1.2.2</encoder-jsp.version>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
+
+        <!--Carbon Multi Tenancy-->
+        <carbon.multitenancy.version>4.11.8</carbon.multitenancy.version>
+        <carbon.multitenancy.imp.pkg.version>[4.9.8, 5.0.0)</carbon.multitenancy.imp.pkg.version>
     </properties>
 
 </project>


### PR DESCRIPTION
## Purpose
Skip executing doPostSetUserClaimValuesWithID in IDV listener in tenant creation flow as it is not required to update idv claim data in tenant creation flow.
Related issue: https://github.com/wso2/product-is/issues/16309
Related PR: https://github.com/wso2/carbon-multitenancy/pull/240