### PR TITLE
Fix management console error when navigating from "Add identity verification provider" section

### DIFF
--- a/components/org.wso2.carbon.extension.identity.verification.ui/src/main/resources/web/idvpmgt/idvp-mgt-edit.jsp
+++ b/components/org.wso2.carbon.extension.identity.verification.ui/src/main/resources/web/idvpmgt/idvp-mgt-edit.jsp
@@ -75,9 +75,10 @@
             idVProvider = idVPMgtClient.getIdVProviderById(idVPId, currentUser);
             idVProviderUIMetadata = extensionMgtClient.getIdVProviderMetadata(idVProvider.getType());
         } else {
-            idVProviderUIMetadata = metadataPerIdVProvider.get(availableIdVPTypes.get(0));
+            if (!metadataPerIdVProvider.isEmpty()) {
+                idVProviderUIMetadata = metadataPerIdVProvider.get(availableIdVPTypes.get(0));
+            }
         }
-
         existingIdVProviderNames = new StringBuilder("[").append(idVPMgtClient.getIdVProviders(null, null, currentUser)
             .stream()
             .map(provider -> "\"" + provider.getIdVProviderName() + "\"")
@@ -89,8 +90,6 @@
         existingIdVProviderNames = new StringBuilder("[]");
         infoPerIdVProvider = new ArrayList<>();
         metadataPerIdVProvider = new HashMap<>();
-        String message = MessageFormat.format(resourceBundle.getString("error.loading.idvp.info"), e.getMessage());
-        CarbonUIMessage.sendCarbonUIMessage(message, CarbonUIMessage.ERROR, request);
     }
     request.setAttribute("infoPerIdVProvider", infoPerIdVProvider);
     request.setAttribute("idVProvider", idVProvider);


### PR DESCRIPTION
### Purpose
This resolves the management console error that occurs when navigating away from an empty "Add identity verification provider" section by handling the associated exception.

### Related Issues
- https://github.com/wso2/product-is/issues/16492
