### PR TITLE
Fix incorrect SQL syntax in PreparedStatement for metadata search

### DIFF
--- a/components/org.wso2.carbon.extension.identity.verification.mgt/src/main/java/org/wso2/carbon/extension/identity/verification/mgt/dao/IdentityVerificationClaimDAOImpl.java
+++ b/components/org.wso2.carbon.extension.identity.verification.mgt/src/main/java/org/wso2/carbon/extension/identity/verification/mgt/dao/IdentityVerificationClaimDAOImpl.java
@@ -223,7 +223,7 @@ public class IdentityVerificationClaimDAOImpl implements IdentityVerificationCla
         List<IdVClaim> idVClaims = new ArrayList<>();
         try (Connection connection = IdentityDatabaseUtil.getDBConnection(false);
              PreparedStatement getIdVProviderStmt = connection.prepareStatement(GET_IDV_CLAIMS_BY_METADATA_SQL)) {
-            // Construct the metadata search pattern using the metadataKey and metadataValue variables
+            // Construct the metadata search pattern using the metadataKey and metadataValue variables.
             String metadataSearchPattern = "%\"" + metadataKey + "\":\"" + metadataValue + "\"%";
             getIdVProviderStmt.setString(1, idvProviderId);
             getIdVProviderStmt.setInt(2, tenantId);

--- a/components/org.wso2.carbon.extension.identity.verification.mgt/src/main/java/org/wso2/carbon/extension/identity/verification/mgt/dao/IdentityVerificationClaimDAOImpl.java
+++ b/components/org.wso2.carbon.extension.identity.verification.mgt/src/main/java/org/wso2/carbon/extension/identity/verification/mgt/dao/IdentityVerificationClaimDAOImpl.java
@@ -223,10 +223,11 @@ public class IdentityVerificationClaimDAOImpl implements IdentityVerificationCla
         List<IdVClaim> idVClaims = new ArrayList<>();
         try (Connection connection = IdentityDatabaseUtil.getDBConnection(false);
              PreparedStatement getIdVProviderStmt = connection.prepareStatement(GET_IDV_CLAIMS_BY_METADATA_SQL)) {
+            // Construct the metadata search pattern using the metadataKey and metadataValue variables
+            String metadataSearchPattern = "%\"" + metadataKey + "\":\"" + metadataValue + "\"%";
             getIdVProviderStmt.setString(1, idvProviderId);
             getIdVProviderStmt.setInt(2, tenantId);
-            getIdVProviderStmt.setString(3, metadataKey);
-            getIdVProviderStmt.setString(4, metadataValue);
+            getIdVProviderStmt.setString(3, metadataSearchPattern);
             getIdVProviderStmt.execute();
             try (ResultSet idVProviderResultSet = getIdVProviderStmt.executeQuery()) {
                 while (idVProviderResultSet.next()) {

--- a/components/org.wso2.carbon.extension.identity.verification.mgt/src/main/java/org/wso2/carbon/extension/identity/verification/mgt/utils/IdentityVerificationConstants.java
+++ b/components/org.wso2.carbon.extension.identity.verification.mgt/src/main/java/org/wso2/carbon/extension/identity/verification/mgt/utils/IdentityVerificationConstants.java
@@ -59,7 +59,7 @@ public class IdentityVerificationConstants {
 
         public static final String GET_IDV_CLAIMS_BY_METADATA_SQL =
                 "SELECT ID, UUID, USER_ID, CLAIM_URI, IS_VERIFIED, METADATA FROM IDV_CLAIM " +
-                        "WHERE IDVP_ID=? AND TENANT_ID=? AND METADATA LIKE '%?:?%'";
+                        "WHERE IDVP_ID=? AND TENANT_ID=? AND METADATA LIKE ?";
 
         public static final String UPDATE_IDV_CLAIM_SQL =
                 "UPDATE IDV_CLAIM SET IS_VERIFIED=?, METADATA=? WHERE USER_ID=? AND UUID=? AND TENANT_ID=?";


### PR DESCRIPTION
## Purpose

- Fix the SQL syntax issue with incorrectly using placeholders (`?`) within a `LIKE` clause string pattern (`'%?:?%'`), which SQL does not support; the fix involved dynamically constructing the `LIKE` pattern in Java before passing it to the `PreparedStatement`, ensuring the query is correctly formed and prevents syntax errors.