### PR TITLE
Add filtering support for identity verification providers list retrieving api.

### DIFF
--- a/components/org.wso2.carbon.extension.identity.verification.provider/pom.xml
+++ b/components/org.wso2.carbon.extension.identity.verification.provider/pom.xml
@@ -149,6 +149,8 @@
                             org.wso2.carbon.identity.base; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.model;
+                            version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.secret.mgt.core;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.secret.mgt.core.exception;

--- a/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/IdVProviderManager.java
+++ b/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/IdVProviderManager.java
@@ -83,6 +83,19 @@ public interface IdVProviderManager {
                                       int tenantId) throws IdVProviderMgtException;
 
     /**
+     * Get all the IdentityVerificationProviders with filtering conditions.
+     *
+     * @param limit    Limit per page.
+     * @param offset   Offset value.
+     * @param filter   Condition to filter.
+     * @param tenantId Tenant Id.
+     * @return List of IdentityVerificationProviders.
+     * @throws IdVProviderMgtException IdVProviderMgtException.
+     */
+    List<IdVProvider> getIdVProviders(Integer limit, Integer offset, String filter,
+                                      int tenantId) throws IdVProviderMgtException;
+
+    /**
      * Get the IdentityVerificationProvider by name.
      *
      * @param idPName  IdentityVerificationProvider name.
@@ -91,6 +104,16 @@ public interface IdVProviderManager {
      * @throws IdVProviderMgtException IdVProviderMgtException.
      */
     IdVProvider getIdVProviderByName(String idPName, int tenantId) throws IdVProviderMgtException;
+
+    /**
+     * Get the count of IdentityVerificationProviders with filtering conditions.
+     *
+     * @param tenantId Tenant Id.
+     * @param filter   Condition to filter.
+     * @return Count of IdentityVerificationProviders.
+     * @throws IdVProviderMgtException IdVProviderMgtException.
+     */
+    int getCountOfIdVProviders(int tenantId, String filter) throws IdVProviderMgtException;
 
     /**
      * Get the count of IdentityVerificationProviders.

--- a/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/dao/CachedBackedIdVProviderDAO.java
+++ b/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/dao/CachedBackedIdVProviderDAO.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.extension.identity.verification.provider.cache.IdVProvide
 import org.wso2.carbon.extension.identity.verification.provider.cache.IdVProviderCacheEntry;
 import org.wso2.carbon.extension.identity.verification.provider.exception.IdVProviderMgtException;
 import org.wso2.carbon.extension.identity.verification.provider.model.IdVProvider;
+import org.wso2.carbon.identity.core.model.ExpressionNode;
 
 import java.util.List;
 
@@ -124,9 +125,23 @@ public class CachedBackedIdVProviderDAO implements IdVProviderDAO {
     }
 
     @Override
+    public List<IdVProvider> getIdVProviders(Integer limit, Integer offset, List<ExpressionNode> expressionNode,
+                                             int tenantId) throws IdVProviderMgtException {
+
+        return idVProviderManagerDAO.getIdVProviders(limit, offset, expressionNode, tenantId);
+    }
+
+    @Override
     public int getCountOfIdVProviders(int tenantId) throws IdVProviderMgtException {
 
         return idVProviderManagerDAO.getCountOfIdVProviders(tenantId);
+    }
+
+    @Override
+    public int getCountOfIdVProviders(int tenantId, List<ExpressionNode> expressionNode)
+            throws IdVProviderMgtException {
+
+        return idVProviderManagerDAO.getCountOfIdVProviders(tenantId, expressionNode);
     }
 
     @Override

--- a/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/dao/IdVProviderDAO.java
+++ b/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/dao/IdVProviderDAO.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.extension.identity.verification.provider.dao;
 
 import org.wso2.carbon.extension.identity.verification.provider.exception.IdVProviderMgtException;
 import org.wso2.carbon.extension.identity.verification.provider.model.IdVProvider;
+import org.wso2.carbon.identity.core.model.ExpressionNode;
 
 import java.util.List;
 
@@ -94,12 +95,33 @@ public interface IdVProviderDAO {
             throws IdVProviderMgtException;
 
     /**
+     * Get Identity Verification Providers with filtering conditions.
+     *
+     * @param limit          Limit.
+     * @param offset         Offset.
+     * @param expressionNode Condition to filter.
+     * @param tenantId       Tenant ID.
+     * @throws IdVProviderMgtException Identity Verification Provider Management Exception.
+     */
+    List<IdVProvider> getIdVProviders(Integer limit, Integer offset, List<ExpressionNode> expressionNode, int tenantId)
+            throws IdVProviderMgtException;
+
+    /**
      * Get Identity Verification Provider count in a given tenant.
      *
      * @param tenantId Tenant ID.
      * @throws IdVProviderMgtException Identity Verification Provider Management Exception.
      */
     int getCountOfIdVProviders(int tenantId) throws IdVProviderMgtException;
+
+    /**
+     * Get Identity Verification Provider count in a given tenant with filtering conditions.
+     *
+     * @param tenantId Tenant ID.
+     * @param expressionNode Condition to filter.
+     * @throws IdVProviderMgtException Identity Verification Provider Management Exception.
+     */
+    int getCountOfIdVProviders(int tenantId, List<ExpressionNode> expressionNode) throws IdVProviderMgtException;
 
     /**
      * Get Identity Verification Provider by name.

--- a/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/model/FilterQueryBuilder.java
+++ b/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/model/FilterQueryBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.extension.identity.verification.provider.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FilterQueryBuilder {
+
+    private Map<Integer, String> stringParameters = new HashMap<>();
+    private int count = 1;
+    private String filter;
+
+    public FilterQueryBuilder() {
+    }
+
+    /**
+     * Returns the map of filter attribute values.
+     *
+     * @return A map where the key is an integer and the value is a string representing the filter attribute value.
+     */
+    public Map<Integer, String> getFilterAttributeValue() {
+
+        return this.stringParameters;
+    }
+
+    /**
+     * Sets a filter attribute value.
+     *
+     * @param value The value to be set as a filter attribute.
+     */
+    public void setFilterAttributeValue(String value) {
+
+        this.stringParameters.put(this.count, value);
+        ++this.count;
+    }
+
+    /**
+     * Resets the filter attribute values to an empty map.
+     */
+    public void setEmptyFilterAttributeValue() {
+        
+        this.stringParameters = new HashMap<>();
+    }
+
+    /**
+     * Sets the filter query string.
+     *
+     * @param filter The filter query string to be set.
+     */
+    public void setFilterQuery(String filter) {
+
+        this.filter = filter;
+    }
+
+    /**
+     * Returns the filter query string.
+     *
+     * @return The filter query string.
+     */
+    public String getFilterQuery() {
+
+        return this.filter;
+    }
+}

--- a/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/util/IdVProviderMgtConstants.java
+++ b/components/org.wso2.carbon.extension.identity.verification.provider/src/main/java/org/wso2/carbon/extension/identity/verification/provider/util/IdVProviderMgtConstants.java
@@ -35,7 +35,19 @@ public class IdVProviderMgtConstants {
     public static final String IS_SECRET = "IS_SECRET";
     public static final String CLAIM = "CLAIM";
     public static final String LOCAL_CLAIM = "LOCAL_CLAIM";
+    public static final String IDVP_FILTER_NAME = "name";
+    public static final String IDVP_FILTER_DESCRIPTION = "description";
+    public static final String IDVP_FILTER_TYPE = "type";
+    public static final String IDVP_FILTER_IS_ENABLED = "isEnabled";
+    public static final String IDVP_FILTER_UUID = "id";
     public static final String SEPERATOR = ":";
+    public static final String EMPTY_STRING = "";
+    public static final String EQ = "eq";
+    public static final String SW = "sw";
+    public static final String EW = "ew";
+    public static final String CO = "co";
+    public static final String IS_TRUE_VALUE = "1";
+    public static final String IS_FALSE_VALUE = "0";
 
     /**
      * This class contains the constants used in the IdVProvider.
@@ -58,7 +70,14 @@ public class IdVProviderMgtConstants {
                 "IDVP WHERE TENANT_ID=? ORDER BY UUID ASC LIMIT ?, ?";
         public static final String GET_IDVPS_SQL_BY_POSTGRESQL = "SELECT ID, UUID, NAME, IDVP_TYPE, DESCRIPTION, IS_ENABLED FROM " +
                 "IDVP WHERE TENANT_ID=? ORDER BY UUID ASC LIMIT ? OFFSET ? ";
+        public static final String GET_IDVPS_SQL_BY_MSSQL_WITH_FILTER = "SELECT ID, UUID, NAME, IDVP_TYPE, DESCRIPTION, IS_ENABLED FROM " +
+                "IDVP WHERE %s TENANT_ID=? ORDER BY UUID OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
+        public static final String GET_IDVPS_SQL_BY_MYSQL_WITH_FILTER = "SELECT ID, UUID, NAME, IDVP_TYPE, DESCRIPTION, IS_ENABLED FROM " +
+                "IDVP WHERE %s TENANT_ID=? ORDER BY UUID ASC LIMIT ?, ?";
+        public static final String GET_IDVPS_SQL_BY_POSTGRESQL_WITH_FILTER = "SELECT ID, UUID, NAME, IDVP_TYPE, DESCRIPTION, IS_ENABLED FROM " +
+                "IDVP WHERE %s TENANT_ID=? ORDER BY UUID ASC LIMIT ? OFFSET ?";
         public static final String GET_COUNT_OF_IDVPS_SQL = "SELECT COUNT(*) FROM IDVP WHERE TENANT_ID=?";
+        public static final String GET_COUNT_OF_IDVPS_SQL_WITH_FILTER = "SELECT COUNT(*) FROM IDVP WHERE %s TENANT_ID=?";
         public static final String DELETE_IDV_SQL = "DELETE FROM IDVP WHERE UUID=? AND TENANT_ID=?";
         public static final String ADD_IDVP_SQL = "INSERT INTO IDVP(UUID, TENANT_ID, NAME, IDVP_TYPE, " +
                 "DESCRIPTION, IS_ENABLED) VALUES (?, ?, ?, ?, ?, ?)";
@@ -85,6 +104,8 @@ public class IdVProviderMgtConstants {
         ERROR_EMPTY_IDVP_ID("60001", "Identity Verification Provider ID value is empty."),
         ERROR_EMPTY_IDVP("60002", "Identity Verification Provider Name is empty."),
         ERROR_UPDATE_IDVP("60003", "Updating Identity Verification Provider Type is not allowed."),
+        ERROR_RETRIEVING_FILTERED_IDV_PROVIDERS("60003",
+                "Error while retrieving Identity Verification Providers: %s."),
 
         // Server errors.
         ERROR_RETRIEVING_IDV_PROVIDERS("65000",

--- a/components/org.wso2.carbon.extension.identity.verification.provider/src/test/java/org/wso2/carbon/extension/identity/verification/provider/util/TestUtils.java
+++ b/components/org.wso2.carbon.extension.identity.verification.provider/src/test/java/org/wso2/carbon/extension/identity/verification/provider/util/TestUtils.java
@@ -22,11 +22,14 @@ import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.extension.identity.verification.provider.model.IdVConfigProperty;
 import org.wso2.carbon.extension.identity.verification.provider.model.IdVProvider;
+import org.wso2.carbon.identity.core.model.ExpressionNode;
 
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,19 +37,29 @@ import java.util.Map;
  */
 public class TestUtils {
 
-    public static final String IDV_PROVIDER_ID = "1c7ce08b-2ebc-4b9e-a107-3b129c019954";
     public static final int TENANT_ID = -1234;
-    public static final String IDV_PROVIDER_NAME = "IdVProviderName";
-    public static final String IDV_PROVIDER_TYPE = "IdVProviderType";
+    public static final String IDV_PROVIDER_1_UUID = "1c7ce08b-2ebc-4b9e-a107-3b129c019954";
+    public static final String IDV_PROVIDER_1_NAME = "IdVProviderName1";
+    public static final String IDV_PROVIDER_1_TYPE = "IdVProviderType1";
+    public static final String IDV_PROVIDER_2_UUID = "4567e08b-2ebc-1234-a107-3b129c019954";
+    public static final String IDV_PROVIDER_2_NAME = "IdVProviderName2";
+    public static final String IDV_PROVIDER_2_TYPE = "IdVProviderType2";
     public static final Map<String, BasicDataSource> dataSourceMap = new HashMap<>();
     public static final String DB_NAME = "test";
 
-    public static IdVProvider getTestIdVProvider() {
+    public static IdVProvider getTestIdVProvider(int id) {
 
         IdVProvider idVProvider = new IdVProvider();
-        idVProvider.setIdVProviderUUID(IDV_PROVIDER_ID);
-        idVProvider.setType(IDV_PROVIDER_TYPE);
-        idVProvider.setIdVProviderName(IDV_PROVIDER_NAME);
+
+        if(id == 1) {
+            idVProvider.setIdVProviderUUID(IDV_PROVIDER_1_UUID);
+            idVProvider.setType(IDV_PROVIDER_1_TYPE);
+            idVProvider.setIdVProviderName(IDV_PROVIDER_1_NAME);
+        } else {
+            idVProvider.setIdVProviderUUID(IDV_PROVIDER_2_UUID);
+            idVProvider.setType(IDV_PROVIDER_2_TYPE);
+            idVProvider.setIdVProviderName(IDV_PROVIDER_2_NAME);
+        }
         idVProvider.setIdVProviderDescription("ONFIDO identity verification provider");
         idVProvider.setEnabled(true);
 
@@ -76,9 +89,9 @@ public class TestUtils {
 
         IdVProvider idVProvider = new IdVProvider();
         idVProvider.setId("1");
-        idVProvider.setIdVProviderUUID(IDV_PROVIDER_ID);
-        idVProvider.setType(IDV_PROVIDER_TYPE);
-        idVProvider.setIdVProviderName(IDV_PROVIDER_NAME);
+        idVProvider.setIdVProviderUUID(IDV_PROVIDER_1_UUID);
+        idVProvider.setType(IDV_PROVIDER_1_TYPE);
+        idVProvider.setIdVProviderName(IDV_PROVIDER_1_NAME);
         idVProvider.setIdVProviderDescription("ONFIDO updated description");
         idVProvider.setEnabled(false);
 
@@ -102,6 +115,15 @@ public class TestUtils {
 
         idVProvider.setIdVConfigProperties(idVConfigProperties);
         return idVProvider;
+    }
+
+    public static List<ExpressionNode> createExpressionNodeList(String attributeValue, String operation, String value) {
+
+        ExpressionNode expressionNode = new ExpressionNode();
+        expressionNode.setAttributeValue(attributeValue);
+        expressionNode.setOperation(operation);
+        expressionNode.setValue(value);
+        return Collections.singletonList(expressionNode);
     }
 
     public static void closeH2Database() throws Exception {


### PR DESCRIPTION
## Purpose

- The current implementation of the API for retrieving the list of Identity Verification Providers does not support filtering. This lack of filtering support limits the ability to narrow down the list of providers based on specific criteria, such as `name`, `type`, `description`, `id` or `isEnabled`. With this PR this limitation is addressed.
- Related issue : https://github.com/wso2/product-is/issues/21213

References : 

[1] https://github.com/wso2/identity-api-server/blob/9df161ac012f91dd7e36d8e568d2587183b1b6d4/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/main/resources/idv-provider.yaml